### PR TITLE
correctif affichage temp sur PVRouteur si dimmer distant

### DIFF
--- a/src/tasks/gettemp.h
+++ b/src/tasks/gettemp.h
@@ -41,7 +41,9 @@ if ( DALLAS == false) {
 
 // hash temp 
 int starttemp = dimmerstate.indexOf(";"); 
-dimmerstate = dimmerstate.substring(starttemp+1); 
+dimmerstate = dimmerstate.substring(starttemp+1);
+int lasttemp = dimmerstate.indexOf(";"); 
+dimmerstate[lasttemp] = '\0'; 
 
 gDisplayValues.temperature = dimmerstate; 
  Serial.println("temperature " + dimmerstate);


### PR DESCRIPTION
Correctif rapide de l'affichage sur le PVRouteur de la température lue sur un dimmer distant