### PR TITLE
démutualisation de la fonction mqtt_send pour domoticz / jeedom

### DIFF
--- a/src/functions/Mqtt_http_Functions.h
+++ b/src/functions/Mqtt_http_Functions.h
@@ -47,43 +47,39 @@ void reconnect() {
 *    Fonction d'envoie info MQTT vers domoticz
 */
 
-void Mqtt_send ( String idx, String value, String otherpub = "" ) {
-  
+void Mqtt_send_domoticz ( String idx, String value ) {
+
   String nvalue = "0" ; 
   
   if ( value != "0" ) { 
-      nvalue = "2" ; 
-      }
-  
-  String message; 
-  if (otherpub == "" ) {
-    message = "  { \"idx\" : " + idx +" ,   \"svalue\" : \"" + value + "\",  \"nvalue\" : " + nvalue + "  } ";
+    nvalue = "2" ; 
   }
 
-  String jdompub = String(config.Publish) + "/"+idx ;
-  if (otherpub != "" ) {jdompub += "/"+otherpub; }
-  
-
+  String message = "  { \"idx\" : " + idx +" ,   \"svalue\" : \"" + value + "\",  \"nvalue\" : " + nvalue + "  } ";
 
   client.loop();
-    if (otherpub == "" ) {
-      if (client.publish(config.Publish, String(message).c_str(), true)) {
-     //   Serial.println("MQTT_send : MQTT sent to domoticz");
-      }
 
-      else {
-        Serial.println("MQTT_send : error publish to domoticz ");
-      }
-    }
-  if (client.publish(jdompub.c_str() , value.c_str(), true)){
-  //  Serial.println("MQTT_send : MQTT sent to Jeedom ");
+  if (client.publish(config.Publish, String(message).c_str(), true)) {
+    //   Serial.println("MQTT_send : MQTT sent to domoticz");
+  } else {
+    Serial.println("MQTT_send : error publish to domoticz ");
   }
-  else {
-Serial.println("MQTT_send : error publish to Jeedom ");
-  }
-  
-
 }
+
+void Mqtt_send_jdom( String idx, String value, String otherpub ) {
+
+  String jdompub = String(config.Publish) + "/" + idx + "/" + otherpub ;
+  
+  client.loop();
+
+  if (client.publish(jdompub.c_str() , value.c_str(), true)){
+    //  Serial.println("MQTT_send : MQTT sent to Jeedom ");
+  } else {
+    Serial.println("MQTT_send : error publish to Jeedom ");
+  }
+}
+
+
 
 /*
 Fonction MQTT callback
@@ -119,7 +115,9 @@ void Mqtt_init() {
   // if (client.connect(pvname,configmqtt.username, configmqtt.password, topic.c_str(), 2, true, "offline")) {       //Connect to MQTT server
   //   client.publish(topic.c_str(), "online", true);         // Once connected, publish online to the availability topic
   //   Serial.println("MQTT_init : connecte a MQTT... Initialisation dimmer à 0");
-     if (config.IDXdimmer != 0 ){ Mqtt_send(String(config.IDXdimmer),"0"); }
+    if (config.IDXdimmer != 0 ) { 
+      Mqtt_send_domoticz( String( config.IDXdimmer ), "0" ); 
+    }
     
   // }
   // else {

--- a/src/functions/dimmerFunction.h
+++ b/src/functions/dimmerFunction.h
@@ -70,7 +70,7 @@ void dimmer_change(char dimmerurl[15], int dimmerIDX, int dimmervalue) {
             if (config.mqtt)  {
             /// A vérifier que c'est necessaire ( envoie double ? )
             /// la valeur 0 doit quand meme être envoyé 
-              Mqtt_send(String(dimmerIDX), String(dimmervalue));
+              Mqtt_send_domoticz(String(dimmerIDX), String(dimmervalue));
               if (configmqtt.HA) device_dimmer.send(String(dimmervalue));
             }
         }

--- a/src/tasks/measure-electricity.h
+++ b/src/tasks/measure-electricity.h
@@ -82,7 +82,9 @@ if (!AP) {
                   long timemesure = start-beforetime;
                   float wattheure = (timemesure * abs(gDisplayValues.watt) / timemilli) ;  
 
-                  if (config.IDX != 0) {Mqtt_send(String(config.IDX), String(int(gDisplayValues.watt)));  }
+                  if (config.IDX != 0) {
+                        Mqtt_send_domoticz(String(config.IDX), String(int(gDisplayValues.watt)));  
+                  }
                   if (configmqtt.HA) {
                         device_routeur.send(String(int(gDisplayValues.watt)));
                         power_apparent.send(String(int(PVA)));
@@ -93,8 +95,9 @@ if (!AP) {
                   // send if injection
                   if (gDisplayValues.watt < 0 ){
                   if (config.IDX != 0) {
-                  Mqtt_send(String(config.IDX), String(int(-gDisplayValues.watt)),"injection");
-                  Mqtt_send(String(config.IDX), String("0") ,"grid");
+                  Mqtt_send_jdom(String(config.IDX), String(int(-gDisplayValues.watt)),"injection");
+                  Mqtt_send_jdom(String(config.IDX), String("0") ,"grid");
+
                   }
                   if (configmqtt.HA) device_inject.send(String(int(-gDisplayValues.watt)));
                   if (configmqtt.HA) device_grid.send(String("0"));
@@ -106,8 +109,8 @@ if (!AP) {
                   }
                   else {
                         if (config.IDX != 0) {
-                  Mqtt_send(String(config.IDX), String("0"),"injection");
-                  Mqtt_send(String(config.IDX), String(int(gDisplayValues.watt)),"grid");
+                              Mqtt_send_jdom(String(config.IDX), String("0"),"injection");
+                              Mqtt_send_jdom(String(config.IDX), String(int(gDisplayValues.watt)),"grid");
                         }
                   if (configmqtt.HA) device_grid.send(String(int(gDisplayValues.watt)));
                   if (configmqtt.HA) device_inject.send(String("0"));


### PR DESCRIPTION
j'ai scindé le mqtt_send en 2 pour jeedom ou domoticz.
je pense qu'on pourrait ajouter, plus tard, a la config,  des checkbox genre : 
mqtt vers domoticz
mqtt vers jeedom
mqtt vers HA   (c'est deja fait :-) )

je ne connais pas assez jeedom, regarde dans les appels dans  dimmerFunction.h @ 73
s'il ne manque pas un send de 0 a jeedom