### PR TITLE
Support des shelly gen1. en triphasé

### DIFF
--- a/src/functions/shelly.h
+++ b/src/functions/shelly.h
@@ -12,64 +12,59 @@ extern Logs logging;
 extern Config config;
 extern DisplayValues gDisplayValues;
 
+int shelly_read_meter(String url, String meter_url, HTTPClient& shelly_http, bool& status) {
+  /// récupération en wget des informations d'un compteur shelly
+  status = false;
+  int shelly_watt = 99999;
+
+  shelly_http.begin(String(url),80,meter_url);    
+  int httpResponseCode = shelly_http.GET();
+  String shelly_state = "0"; 
+  shelly_state = shelly_http.getString();
+  shelly_http.end();
+
+  if (httpResponseCode==200) {
+      
+      JsonDocument doc;
+      DeserializationError error = deserializeJson(doc, shelly_state);
+
+      /// protection de la validité du json
+      if (error) {
+          Serial.print(F("deserializeJson() failed: "));
+          logging.Set_log_init("deserializeJson() failed: ",true);
+          Serial.println(error.c_str());
+      }
+      else {
+        auto powerValue = doc["power"];
+
+        /// protection de la donnée
+        if (powerValue.is<int>() || powerValue.is<float>()) {
+            shelly_watt = powerValue.as<int>();
+            status = true;
+        }
+      }
+    }
+  return shelly_watt;
+}
+
 
 int shelly_get_data(String url) {
- /// récupération en wget des informations du shelly 
-HTTPClient shelly_http;
+ /// récupération en wget des informations du shelly
+  HTTPClient shelly_http;
   int shelly_watt = 0;
+  bool status = true;
   
   if (WiFi.status() == WL_CONNECTED) {   // si connecté on wget
 
     String baseurl = "/emeter/0" ; 
-        /// mode triphasé
-      if ( config.Shelly_tri ) {
-        baseurl = "/rpc/EM.GetStatus?id=0" ; 
+    shelly_watt = shelly_read_meter(url, baseurl, shelly_http, status);
+
+    if ( status && config.Shelly_tri ) {
+        shelly_watt += shelly_read_meter(url, "/emeter/1", shelly_http,status);
+        shelly_watt += status ? shelly_read_meter(url, "/emeter/2", shelly_http, status) : 0;
       }
-
-    shelly_http.begin(String(url),80,baseurl);   
-        
-        int httpResponseCode = shelly_http.GET();
-        String shelly_state = "0"; 
-        shelly_state = shelly_http.getString();
-        shelly_http.end();
-        if (httpResponseCode==200) {
-            shelly_watt = 99999;
-            JsonDocument doc;
-            DeserializationError error = deserializeJson(doc, shelly_state);
-
-            /// protection de la validité du json
-            if (error) {
-                Serial.print(F("deserializeJson() failed: "));
-                logging.Set_log_init("deserializeJson() failed: ",true);
-                Serial.println(error.c_str());
-                shelly_watt = 99999;
-                return shelly_watt;
-            }
-
-            auto powerValue = doc["power"];
-              /// mode triphasé
-              if (config.Shelly_tri ) { 
-                powerValue = doc["total_act_power"];
-              }
-
-            
-
-            /// protection de la donnée
-            if (powerValue.is<int>() || powerValue.is<float>()) {
-                shelly_watt = powerValue.as<int>();
-            }
-            else {
-                shelly_watt = 99999;
-            }
-
-        }
-        else {
-            shelly_watt = 99999;
-        }
     } 
-
-return shelly_watt; 
-
+  return status ? shelly_watt : 99999; 
 }
 
 bool checkIP(String inputString) {

--- a/src/functions/shelly.h
+++ b/src/functions/shelly.h
@@ -71,11 +71,7 @@ bool checkIP(String inputString) {
   IPAddress ip;
   
   // Essayez de convertir la chaîne en adresse IP
-  if (ip.fromString(inputString)) {
-    return true;
-  } else {
-    return false;
-  }
+  return (ip.fromString(inputString));
 }
 
 


### PR DESCRIPTION
Proposition de changement d'api shelly pour supporter les devices de premiere generation.
Normalement pas d'effet de bord pour le monophasé.

### Changements: 
- Actuel: la lecture des données triphasée utilise l'api shelly generation 2 (inclus uniquement 3em pro): https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/EM
- Proposition: utilisation de l'API compatible avec les matériels de génération 1 (dont 3em): https://shelly-api-docs.shelly.cloud/gen1/#shelly-3em-emeter-index

### Discussion
Testé uniquement avec shelly 3em. Je suis parti du principe que le 3em-pro était rétro-compatible avec l'api gen1., mais je n'ai pas de quoi tester.

### Explication des changements
J'ai déporté le code de requête http de la fonction `shelly_get_data` vers `shelly_read_meter()`. Dans le cas du tri, les trois compteurs sont interrogés (et accumulés) successivement, sauf en cas d'erreur de lecture.
J'ai également légèrement factorisé et nettoyé le code.